### PR TITLE
fix: retry on CRC errors up until the configured read timeout

### DIFF
--- a/src/RTUMaster.cpp
+++ b/src/RTUMaster.cpp
@@ -38,7 +38,13 @@ void RTUMaster::readFrame(Frame& frame) {
     int c = readRaw(&m_read_buffer[0], m_read_buffer.size(),
                     getReadTimeout(), getReadTimeout(), m_interframe_delay);
 
-    RTU::parseFrame(frame, &m_read_buffer[0], &m_read_buffer[c]);
+    try {
+        RTU::parseFrame(frame, &m_read_buffer[0], &m_read_buffer[c]);
+    }
+    catch(...) {
+        m_stats.bad_rx += c;
+        throw;
+    }
 }
 
 Frame const& RTUMaster::request(int address, int function, vector<uint8_t> const& payload) {

--- a/src/RTUMaster.hpp
+++ b/src/RTUMaster.hpp
@@ -54,6 +54,11 @@ namespace modbus {
 
         static const int FUNCTION_CODE_EXCEPTION = 0x80;
 
+        void writePacketAndReadReply(
+            uint8_t const* buffer, int bufsize,
+            Frame& frame, int function
+        );
+
     public:
         RTUMaster();
 

--- a/test/test_RTUMaster.cpp
+++ b/test/test_RTUMaster.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <modbus/RTU.hpp>
 #include <modbus/RTUMaster.hpp>
 #include <modbus/Exceptions.hpp>
 #include <iodrivers_base/FixtureGTest.hpp>
@@ -139,6 +140,34 @@ TEST_F(RTUMasterTest, it_does_a_modbus_broadcast) {
 
     uint8_t expected[] = { 0x00, 0x10, 6, 7, 8, 9, 0xB7, 0x57 };
     ASSERT_THAT(bytes, ElementsAreArray(expected));
+}
+
+TEST_F(RTUMasterTest, it_retries_on_CRC_error) {
+    driver.openURI("test://");
+
+    IODRIVERS_BASE_MOCK();
+    EXPECT_REPLY(
+        vector<uint8_t>{ 0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91 },
+        vector<uint8_t>{ 0x10, 0x03, 0x4, 0x12, 0x34, 0x56, 0x78, 0x80, 0x07 }
+    );
+    EXPECT_REPLY(
+        vector<uint8_t>{ 0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91 },
+        vector<uint8_t>{ 0x10, 0x03, 0x4, 0x12, 0x34, 0x56, 0x78, 0x80, 0x06 }
+    );
+    ASSERT_EQ((vector<uint16_t>{ 0x1234, 0x5678 }),
+              driver.readRegisters(0x10, false, 0xabcd, 2));
+}
+
+TEST_F(RTUMasterTest, it_does_timeout_if_the_CRC_error_is_permanent) {
+    driver.openURI("test://");
+
+    IODRIVERS_BASE_MOCK();
+    EXPECT_REPLY(
+        vector<uint8_t>{ 0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91 },
+        vector<uint8_t>{ 0x10, 0x03, 0x4, 0x12, 0x34, 0x56, 0x78, 0x80, 0x07 }
+    );
+    driver.setReadTimeout(Time());
+    ASSERT_THROW(driver.readRegisters(0x10, false, 0xabcd, 2), modbus::RTU::InvalidCRC);
 }
 
 TEST_F(RTUMasterTest, it_does_a_holding_register_read_request) {

--- a/test/test_RTUMaster.cpp
+++ b/test/test_RTUMaster.cpp
@@ -158,6 +158,22 @@ TEST_F(RTUMasterTest, it_retries_on_CRC_error) {
               driver.readRegisters(0x10, false, 0xabcd, 2));
 }
 
+TEST_F(RTUMasterTest, it_accounts_for_invalid_data) {
+    driver.openURI("test://");
+
+    IODRIVERS_BASE_MOCK();
+    EXPECT_REPLY(
+        vector<uint8_t>{ 0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91 },
+        vector<uint8_t>{ 0x10, 0x03, 0x4, 0x12, 0x34, 0x56, 0x78, 0x80, 0x07 }
+    );
+    EXPECT_REPLY(
+        vector<uint8_t>{ 0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91 },
+        vector<uint8_t>{ 0x10, 0x03, 0x4, 0x12, 0x34, 0x56, 0x78, 0x80, 0x06 }
+    );
+    driver.readRegisters(0x10, false, 0xabcd, 2);
+    ASSERT_EQ(9, driver.getStatus().bad_rx);
+}
+
 TEST_F(RTUMasterTest, it_does_timeout_if_the_CRC_error_is_permanent) {
     driver.openURI("test://");
 


### PR DESCRIPTION
Turns out serial (i.e. RTU) is not as robust a communication medium as we'd like it to be
(shocker, yes, I know)