### PR TITLE
fix: handle modbus::RTU::TooSmall exception in retry loop

### DIFF
--- a/src/RTUMaster.cpp
+++ b/src/RTUMaster.cpp
@@ -143,6 +143,12 @@ void RTUMaster::writePacketAndReadReply(uint8_t const* buffer,
                 throw;
             }
         }
+        catch (modbus::RTU::TooSmall const&) {
+            m_statistics.total_too_small_error_count++;
+            if (increaseErrorCountAndValidate()) {
+                throw;
+            }
+        }
     } while (true);
 }
 

--- a/src/RTUStatistics.hpp
+++ b/src/RTUStatistics.hpp
@@ -34,6 +34,9 @@ namespace modbus {
          */
         uint32_t total_unexpected_reply_error_count = 0;
 
+        /** Total amount of replies where the frame received was too small */
+        uint32_t total_too_small_error_count = 0;
+
         /** Total amount of messages that passed validation */
         uint64_t total_success_count = 0;
 

--- a/test/test_RTUMaster.cpp
+++ b/test/test_RTUMaster.cpp
@@ -171,6 +171,33 @@ TEST_F(RTUMasterTest, it_retries_on_unexpected_reply_length)
     ASSERT_EQ(1, statistics.total_success_count);
 }
 
+TEST_F(RTUMasterTest, it_retries_on_TooSmall)
+{
+    driver.openURI("test://");
+    driver.setErrorIncrement(3);
+    driver.setErrorThreshold(12);
+
+    IODRIVERS_BASE_MOCK();
+    EXPECT_REPLY(vector<uint8_t>{0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91},
+        vector<uint8_t>{0x10, 0x03, 0x4});
+    EXPECT_REPLY(vector<uint8_t>{0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91},
+        vector<uint8_t>{0x10, 0x03, 0x4});
+    EXPECT_REPLY(vector<uint8_t>{0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91},
+        vector<uint8_t>{0x10, 0x03, 0x4});
+    EXPECT_REPLY(vector<uint8_t>{0x10, 0x03, 0xab, 0xcd, 0x00, 0x02, 0x76, 0x91},
+        vector<uint8_t>{0x10, 0x03, 0x4, 0x12, 0x34, 0x56, 0x78, 0x80, 0x06});
+
+    ASSERT_EQ((vector<uint16_t>{0x1234, 0x5678}),
+        driver.readRegisters(0x10, false, 0xabcd, 2));
+    auto statistics = driver.getRTUStats();
+    // It tries thrice (+9) and then it succeeds once (-1)
+    ASSERT_EQ(8, statistics.error_count);
+    ASSERT_EQ(0, statistics.total_crc_error_count);
+    ASSERT_EQ(0, statistics.total_unexpected_reply_error_count);
+    ASSERT_EQ(3, statistics.total_too_small_error_count);
+    ASSERT_EQ(1, statistics.total_success_count);
+}
+
 TEST_F(RTUMasterTest, it_accounts_for_invalid_data)
 {
     driver.openURI("test://");


### PR DESCRIPTION
Ensures that `modbus::RTU::TooSmall` (which is thrown when a read times out and returns an empty frame) is properly handled within the driver's retry loop. Instead of throwing the execution cycle, it now correctly increments the error count.

Also, a new `total_too_small_error_count` field has been added to `RTUStatistics` to track these specific errors.

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
